### PR TITLE
Define liveness/readiness Probes for k8guard-report

### DIFF
--- a/minikube/report/k8guard-report-deployment.yaml
+++ b/minikube/report/k8guard-report-deployment.yaml
@@ -63,3 +63,14 @@ spec:
                 key: cassandra-ssl-validation
         ports:
         - containerPort: 3001
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: 3001
+          initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3001
+          initialDelaySeconds: 10
+          timeoutSeconds: 3


### PR DESCRIPTION
This PR covers a part of the issue #15 .

Note that firstly we have to merge the following PR for `k8guard-report` repo, which defines the endpoints in the server-side: https://github.com/k8guard/k8guard-report/pull/13