### PR TITLE
Additional violations

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -63,7 +63,7 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 
 
 # Optional
-# Ignore violations, comma seprated values.
+# Ignore violations, comma separated values.
 # Example SINGLE_REPLICA, IMAGE_REPO, IMAGE_SIZE, HOST_VOLUMES, INGRESS_HOST_INVALID, PRIVILIGED, CAPABILITES
 K8GUARD_IGNORED_VIOLATIONS=
 
@@ -76,6 +76,11 @@ K8GUARD_IGNORE_NAMESPACES=
 # Optional
 # ignore pods with these prefix, comma separated values
 K8GUARD_IGNORE_PODS_PREFIX=
+
+# Optional
+# Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
+# Example mynamespace:kube2iam, myothernamespace:myotherdaemonset
+K8GUARD_REQUIRED_DAEMONSETS=
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -65,9 +65,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 # Optional
 # Ignore violations, comma separated values.
 # To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
-# Alternatively, filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
-# When using the `{namespace}:{entityType}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
-# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,REQUIRED_POD_ANNOTATIONS,*:kube2iam:PRIVILEGED
+# Alternatively, filter by namespace and/or entity type / name using the format `{namespace}:{entityType}:{entityName}:{value}`.
+# When using the `{namespace}:{entityType}:{entityName}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,*:*:kube2iam:PRIVILEGED
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -82,19 +82,19 @@ K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
 # Verify presence of specific  annotations, comma separated values.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_ANNOTATIONS=
 
 # Optional
 # Verify presence of specific  labels, comma separated values.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_LABELS=
 
 # Optional
 # Verify that the following entities are deployed within a specific namespace, comma separated.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_ENTITIES=
 

--- a/.env-template
+++ b/.env-template
@@ -65,8 +65,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 # Optional
 # Ignore violations, comma separated values.
 # To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
-# To ignore for a specific object, prefix with the object name and a colon, e.g. 'kube2iam:PRIVILEGED'
-# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED, CAPABILITES,REQUIRED_POD_ANNOTATIONS
+# Alternatively, filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# When using the `{namespace}:{entityType}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,REQUIRED_POD_ANNOTATIONS,*:kube2iam:PRIVILEGED
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -80,15 +81,22 @@ K8GUARD_IGNORE_NAMESPACES=
 K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
-# Verify presence of specific annotations, comma separated values.
-# (e.g. enforce use of kube2iam by checking for 'iam.amazonaws.com/role' annotation)
-K8GUARD_POD_REQUIRED_ANNOTATIONS=
-
+# Verify presence of specific  annotations, comma separated values.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_ANNOTATIONS=
 
 # Optional
-# Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
-# Example mynamespace:kube2iam,myothernamespace:myotherdaemonset
-K8GUARD_REQUIRED_DAEMONSETS=
+# Verify presence of specific  labels, comma separated values.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_LABELS=
+
+# Optional
+# Verify that the following entities are deployed within a specific namespace, comma separated.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_ENTITIES=
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -96,7 +96,7 @@ K8GUARD_REQUIRED_LABELS=
 # Verify that the following entities are deployed within a specific namespace, comma separated.
 # Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
-# Supported entity types are namespace, deployment and daemonset
+# Supported entity types are namespace, deployment, daemonset and resourcequota
 K8GUARD_REQUIRED_ENTITIES=
 
 

--- a/.env-template
+++ b/.env-template
@@ -35,6 +35,10 @@ K8GUARD_ACTION_DURATION_BETWEEN_NOTIFYING_AGAIN=24h
 # Hint 120h is for 5 days. that means if violation not resolved by 5 days, it will create a new violation for the owner.
 K8GUARD_ACTION_DURATION_VIOLATION_EXPIRES=120h
 
+# Required
+# Use of alpha functionality may not be included in some distributions such as Tectonic, or enabled by default
+K8GUARD_INCLUDE_ALPHA=FALSE
+
 
 
 #----------------------------------------------------------

--- a/.env-template
+++ b/.env-template
@@ -64,7 +64,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 
 # Optional
 # Ignore violations, comma separated values.
-# Example SINGLE_REPLICA, IMAGE_REPO, IMAGE_SIZE, HOST_VOLUMES, INGRESS_HOST_INVALID, PRIVILIGED, CAPABILITES
+# To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
+# To ignore for a specific object, prefix with the object name and a colon, e.g. 'kube2iam:PRIVILEGED'
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED, CAPABILITES,REQUIRED_POD_ANNOTATIONS
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -78,8 +80,14 @@ K8GUARD_IGNORE_NAMESPACES=
 K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
+# Verify presence of specific annotations, comma separated values.
+# (e.g. enforce use of kube2iam by checking for 'iam.amazonaws.com/role' annotation)
+K8GUARD_POD_REQUIRED_ANNOTATIONS=
+
+
+# Optional
 # Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
-# Example mynamespace:kube2iam, myothernamespace:myotherdaemonset
+# Example mynamespace:kube2iam,myothernamespace:myotherdaemonset
 K8GUARD_REQUIRED_DAEMONSETS=
 
 

--- a/.env-template
+++ b/.env-template
@@ -37,7 +37,7 @@ K8GUARD_ACTION_DURATION_VIOLATION_EXPIRES=120h
 
 # Required
 # Use of alpha functionality may not be included in some distributions such as Tectonic, or enabled by default
-K8GUARD_INCLUDE_ALPHA=FALSE
+K8GUARD_INCLUDE_ALPHA=TRUE
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -94,8 +94,9 @@ K8GUARD_REQUIRED_LABELS=
 
 # Optional
 # Verify that the following entities are deployed within a specific namespace, comma separated.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Supported entity types are namespace, deployment and daemonset
 K8GUARD_REQUIRED_ENTITIES=
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env-creds
 minikube/action/k8guard-action-secrets.yaml
 minikube/report/k8guard-report-secrets.yaml
+/.project


### PR DESCRIPTION
Enhanced the rule configuration to allow setting per namespace and/or entity type, as well as exclusions.  Note that this is fully backwards compatible with the previous method.

Examples of new rule format:
- `K8GUARD_IGNORED_VIOLATIONS=mynamespace:*:*:PRIVILEGED`	- will ignore `PRIVILEGED` for all types within `mynamespace`. 
- `K8GUARD_IGNORED_VIOLATIONS=!mynamespace:daemonset:*:PRIVILEGED`	- will ignore `PRIVILEGED` for all daemonsets in any namespace but `mynamespace`.
- `K8GUARD_IGNORED_VIOLATIONS=*:daemonset:kube2iam:PRIVILEGED`	- will ignore `PRIVILEGED` only for daemonsets named `kube2iam` across all namespaces.

In addition, added the following new config values which use the `{namespace}:{entitytype}.{entityName}:{value}` format as described above:
- `K8GUARD_REQUIRED_ANNOTATIONS`
- `K8GUARD_REQUIRED_LABELS`
- `K8GUARD_REQUIRED_ENTITIES`

The only existing config variable that has been transitioned over to the `{namespace}:{entitytype}.{entityName}:{value}` format is `K8GUARD_IGNORED_VIOLATIONS`.