### PR TITLE
Lighterweight dependencies

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -102,9 +102,13 @@ K8GUARD_REQUIRED_ENTITIES=
 
 
 #----------------------------------------------------------
-#   Kafka Cassandra Memcached
+#   Kafka Redis Cassandra Memcached
 #---------------------------------------------------------
 
+# Optional
+# Which caching system to use?  Supported values MEMCACHED and REDIS.  
+# Default MEMCACHED
+K8GUARD_CACHE_TYPE=
 
 # Required
 # Memcached expiration in seconds for stuff like (image size, discover-api response)
@@ -112,9 +116,19 @@ K8GUARD_MEMCACHED_HOSTNAME=memcached
 
 K8GUARD_CACHE_EXPIRATION_SECONDS=300
 
+# Optional
+# Which messaging system to use?  Supported values KAFKA and RMQ.  
+# Default KAFKA
+K8GUARD_MESSAGE_BROKER=
+
+# Only required if `K8GUARD_MESSAGE_BROKER=RMQ`
+K8GUARD_RMQ_BROKER=redis:6379
+K8GUARD_RMQ_ACTION_TOPIC=k8guard-to-action
+K8GUARD_RMQ_EVENT_TOPIC=k8guard-events
+
+# Only required if `K8GUARD_MESSAGE_BROKER=KAFKA`
 K8GUARD_KAFKA_BROKERS=kafka:9092
 K8GUARD_KAFKA_ACTION_TOPIC=k8guard-to-action
-
 # Optional, experimental feature
 K8GUARD_KAFKA_EVENT_TOPIC=k8guard-events
 

--- a/.env-template
+++ b/.env-template
@@ -63,7 +63,7 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 
 
 # Optional
-# Ignore violations, comma seprated values.
+# Ignore violations, comma separated values.
 # Example SINGLE_REPLICA, IMAGE_REPO, IMAGE_SIZE, HOST_VOLUMES, INGRESS_HOST_INVALID, PRIVILIGED, CAPABILITES
 K8GUARD_IGNORED_VIOLATIONS=
 
@@ -76,6 +76,11 @@ K8GUARD_IGNORE_NAMESPACES=
 # Optional
 # ignore pods with these prefix, comma separated values
 K8GUARD_IGNORE_PODS_PREFIX=
+
+# Optional
+# Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
+# Example mynamespace:kube2iam, myothernamespace:myotherdaemonset
+K8GUARD_REQUIRED_DAEMONSETS=
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -65,9 +65,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 # Optional
 # Ignore violations, comma separated values.
 # To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
-# Alternatively, filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
-# When using the `{namespace}:{entityType}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
-# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,REQUIRED_POD_ANNOTATIONS,*:kube2iam:PRIVILEGED
+# Alternatively, filter by namespace and/or entity type / name using the format `{namespace}:{entityType}:{entityName}:{value}`.
+# When using the `{namespace}:{entityType}:{entityName}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,*:*:kube2iam:PRIVILEGED
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -82,19 +82,19 @@ K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
 # Verify presence of specific  annotations, comma separated values.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_ANNOTATIONS=
 
 # Optional
 # Verify presence of specific  labels, comma separated values.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_LABELS=
 
 # Optional
 # Verify that the following entities are deployed within a specific namespace, comma separated.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
 K8GUARD_REQUIRED_ENTITIES=
 

--- a/.env-template
+++ b/.env-template
@@ -65,8 +65,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 # Optional
 # Ignore violations, comma separated values.
 # To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
-# To ignore for a specific object, prefix with the object name and a colon, e.g. 'kube2iam:PRIVILEGED'
-# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED, CAPABILITES,REQUIRED_POD_ANNOTATIONS
+# Alternatively, filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# When using the `{namespace}:{entityType}:{value}` format, optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED,CAPABILITES,REQUIRED_POD_ANNOTATIONS,*:kube2iam:PRIVILEGED
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -80,15 +81,22 @@ K8GUARD_IGNORE_NAMESPACES=
 K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
-# Verify presence of specific annotations, comma separated values.
-# (e.g. enforce use of kube2iam by checking for 'iam.amazonaws.com/role' annotation)
-K8GUARD_POD_REQUIRED_ANNOTATIONS=
-
+# Verify presence of specific  annotations, comma separated values.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_ANNOTATIONS=
 
 # Optional
-# Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
-# Example mynamespace:kube2iam,myothernamespace:myotherdaemonset
-K8GUARD_REQUIRED_DAEMONSETS=
+# Verify presence of specific  labels, comma separated values.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_LABELS=
+
+# Optional
+# Verify that the following entities are deployed within a specific namespace, comma separated.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{value}`.
+# Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+K8GUARD_REQUIRED_ENTITIES=
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -96,7 +96,7 @@ K8GUARD_REQUIRED_LABELS=
 # Verify that the following entities are deployed within a specific namespace, comma separated.
 # Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
-# Supported entity types are namespace, deployment and daemonset
+# Supported entity types are namespace, deployment, daemonset and resourcequota
 K8GUARD_REQUIRED_ENTITIES=
 
 

--- a/.env-template
+++ b/.env-template
@@ -64,7 +64,9 @@ K8GUARD_APPROVED_INGRESS_SUFFIXES=
 
 # Optional
 # Ignore violations, comma separated values.
-# Example SINGLE_REPLICA, IMAGE_REPO, IMAGE_SIZE, HOST_VOLUMES, INGRESS_HOST_INVALID, PRIVILIGED, CAPABILITES
+# To ignore the violation completely for everything, just add the violation name, e.g. 'PRIVILEGED'
+# To ignore for a specific object, prefix with the object name and a colon, e.g. 'kube2iam:PRIVILEGED'
+# Example SINGLE_REPLICA,IMAGE_REPO,IMAGE_SIZE,HOST_VOLUMES,INGRESS_HOST_INVALID,PRIVILEGED, CAPABILITES,REQUIRED_POD_ANNOTATIONS
 K8GUARD_IGNORED_VIOLATIONS=
 
 
@@ -78,8 +80,14 @@ K8GUARD_IGNORE_NAMESPACES=
 K8GUARD_IGNORE_PODS_PREFIX=
 
 # Optional
+# Verify presence of specific annotations, comma separated values.
+# (e.g. enforce use of kube2iam by checking for 'iam.amazonaws.com/role' annotation)
+K8GUARD_POD_REQUIRED_ANNOTATIONS=
+
+
+# Optional
 # Verify that the following DaemonSets are deployed within a specific namespace (format namespace:daemonset), comma separated.
-# Example mynamespace:kube2iam, myothernamespace:myotherdaemonset
+# Example mynamespace:kube2iam,myothernamespace:myotherdaemonset
 K8GUARD_REQUIRED_DAEMONSETS=
 
 

--- a/.env-template
+++ b/.env-template
@@ -37,7 +37,7 @@ K8GUARD_ACTION_DURATION_VIOLATION_EXPIRES=120h
 
 # Required
 # Use of alpha functionality may not be included in some distributions such as Tectonic, or enabled by default
-K8GUARD_INCLUDE_ALPHA=FALSE
+K8GUARD_INCLUDE_ALPHA=TRUE
 
 
 

--- a/.env-template
+++ b/.env-template
@@ -94,8 +94,9 @@ K8GUARD_REQUIRED_LABELS=
 
 # Optional
 # Verify that the following entities are deployed within a specific namespace, comma separated.
-# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}:{value}`.
+# Filter by namespace and/or entity type using the format `{namespace}:{entityType}:{entityName}`.
 # Optionally specify `*` to include all of that type, or prefix with `!` to exclude
+# Supported entity types are namespace, deployment and daemonset
 K8GUARD_REQUIRED_ENTITIES=
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ build-report-local-docker:
 build-local-dockers: build-action-local-docker build-discover-local-docker build-report-local-docker ## Builds all the docker images locally from source code
 
 
-####################################################################
-#######		original docker compose using kafka/zookeeper    #######
-####################################################################
+#############################################################################
+#######		original docker compose using memcache/kafka/zookeeper    #######
+#############################################################################
 
 clean-compose: clean-action-compose clean-discover-compose clean-report-compose clean-core-compose
 
@@ -154,9 +154,9 @@ up-report-compose-lightweight-d: clean-report-compose-lightweight
 up-compose-lightweight: up-core-compose-lightweight up-action-compose-lightweight-d up-discover-compose-lightweight-d up-report-compose-lightweight-d ## deploys all the microservices to dokcer-compose
 
 
-#########################################################################
-#######		original minikube deployment using kafka/zookepper    #######
-#########################################################################
+##################################################################################
+#######		original minikube deployment using memcache/kafka/zookepper    #######
+##################################################################################
 
 clean-minikube: ## delete all pods and jobs on the minikube
 	kubectl delete -f minikube/core || true

--- a/docker-compose-action-lightweight.yaml
+++ b/docker-compose-action-lightweight.yaml
@@ -1,0 +1,21 @@
+---
+services:
+  k8guard-action:
+    build:
+      context: ../k8guard-action/
+      dockerfile: Dockerfile-local
+    external_links:
+      - k8guardstartfromhere_redis_1:redis
+      - k8guardstartfromhere_cassandra_1:cassandra
+    networks:
+      - k8guardstartfromhere_default
+    env_file:
+      - .env-creds
+      - .env
+    volumes:
+      - ${HOME}/.kube:/root/.kube
+      # - ${HOME}/.minikube:${HOME}/.minikube # only if you want docker-compose k8guard to run against a minikube.
+version: "2"
+networks:
+  k8guardstartfromhere_default:
+    external: true

--- a/docker-compose-core-lightweight.yaml
+++ b/docker-compose-core-lightweight.yaml
@@ -1,0 +1,13 @@
+---
+services:
+  cassandra:
+    image: bitnami/cassandra
+    environment:
+      CASSANDRA_CLUSTER_NAME: cassandra
+    
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
+
+version: "2"

--- a/docker-compose-discover-lightweight.yaml
+++ b/docker-compose-discover-lightweight.yaml
@@ -11,6 +11,7 @@ services:
       - .env
     ports:
       - 3000:3000
+      - 3002:3002
     volumes:
       - ${HOME}/.kube:/root/.kube
       # - ${HOME}/.minikube:${HOME}/.minikube # only if you want docker-compose k8guard to run against a minikube.

--- a/docker-compose-discover-lightweight.yaml
+++ b/docker-compose-discover-lightweight.yaml
@@ -1,0 +1,36 @@
+---
+services:
+  k8guard-discover-api:
+    build:
+      context: ../k8guard-discover/
+    networks:
+      - k8guardstartfromhere_default
+    external_links:
+      - k8guardstartfromhere_redis_1:redis
+    env_file:
+      - .env
+    ports:
+      - 3000:3000
+    volumes:
+      - ${HOME}/.kube:/root/.kube
+      # - ${HOME}/.minikube:${HOME}/.minikube # only if you want docker-compose k8guard to run against a minikube.
+  k8guard-discover-cron:
+    build:
+      context: ../k8guard-discover/
+      dockerfile: Dockerfile-local
+    networks:
+      - k8guardstartfromhere_default
+    env_file:
+      - .env
+    external_links:
+      - k8guardstartfromhere_redis_1:redis
+    volumes:
+      - ${HOME}/.kube:/root/.kube
+      - ${HOME}/.minikube:${HOME}/.minikube
+    command:
+      - -kmode
+version: "2"
+
+networks:
+  k8guardstartfromhere_default:
+    external: true

--- a/docker-compose-report-lightweight.yaml
+++ b/docker-compose-report-lightweight.yaml
@@ -1,0 +1,19 @@
+---
+services:
+  k8guard-report:
+    build:
+      context: ../k8guard-report/
+    networks:
+      - k8guardstartfromhere_default
+    external_links:
+      - k8guardstartfromhere_cassandra_1:cassandra
+    env_file:
+      - .env
+      - .env-creds
+    ports:
+      - 3001:3001
+version: "2"
+
+networks:
+  k8guardstartfromhere_default:
+    external: true

--- a/minikube/action-lightweight/k8guard-action-configmap.yaml
+++ b/minikube/action-lightweight/k8guard-action-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-action-configmap
+data:
+  cluster-name: "minikube"
+  hipchat-room-id: ""
+  hipchat-base-url: ""
+  hipchat-tag-namespace-owner: "true"
+  k8guard-log-level: "debug"
+  k8guard-cache-type: "REDIS"
+  k8guard-message-broker: "RMQ"
+  k8guard-rmq-broker: "redis:6379"
+  k8guard-rmq-action-topic: "k8guard-to-action"
+  cassandra-hosts: "k8guard-cassandra-service.default.svc.cluster.local:9042"
+  cassandra-keyspace: "k8guardkeyspace"
+  cassandra-username: "cassandra"
+  cassandra-ca-path: ""
+  cassandra-ssl-validation: "false"
+  k8guard-cassandra-create-keyspace: "true"
+  k8guard-cassandra-create-tables: "true"
+  smtp-server: ""
+  smtp-port: "25"
+  smtp-send-from: "DO_NOT_REPLY@REPLACE_WITH_DOMAIN.COM"
+  smtp-fallback-send-to: "REPLACE@REPLACE_WITH_DOMAIN.COM"
+  smtp-send-to-namespace-owner: "true"
+  action-safe-mode: "true"
+  action-dry-run: "false"
+  action-duration-between-chat-notifications: "30s"
+  action-warning-count-before_action: "4"
+  action-duration-between-notifying-again: "24h"
+  action-duration-violation-expires: "120h"
+  k8guard-action-violation-email-footer: ""

--- a/minikube/action-lightweight/k8guard-action-deployment.yaml
+++ b/minikube/action-lightweight/k8guard-action-deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-action-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8guard-action
+    spec:
+      containers:
+      - name: k8guard-action
+        image: local/k8guard-action
+        imagePullPolicy: Never
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cluster-name
+          - name: K8GUARD_ACTION_CASSANDRA_HOSTS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-hosts
+          - name: K8GUARD_ACTION_CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-keyspace
+          - name: K8GUARD_ACTION_CASSANDRA_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-username
+          - name: K8GUARD_ACTION_CASSANDRA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-action-secrets
+                key: cassandra-password
+          - name: K8GUARD_ACTION_CASSANDRA_CAPATH
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-ca-path
+          - name: K8GUARD_ACTION_CASSANDRA_SSL_HOST_VALIDATION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-ssl-validation
+          - name: K8GUARD_ACTION_SMTP_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-server
+          - name: K8GUARD_ACTION_SMTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-port
+          - name: K8GUARD_ACTION_SMTP_SEND_FROM
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-send-from
+          - name: K8GUARD_ACTION_SMTP_FALLBACK_SEND_TO
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-fallback-send-to
+          - name: K8GUARD_ACTION_SMTP_SEND_TO_NAMESAPCE_OWNER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-send-to-namespace-owner
+          - name: K8GUARD_ACTION_SAFE_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-safe-mode
+          - name: K8GUARD_ACTION_DRY_RUN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-dry-run
+          - name: K8GUARD_ACTION_WARNING_COUNT_BEFORE_ACTION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-warning-count-before_action
+          - name: K8GUARD_ACTION_DURATION_BETWEEN_CHAT_NOTIFICATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-between-chat-notifications
+          - name: K8GUARD_ACTION_DURATION_BETWEEN_NOTIFYING_AGAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-between-notifying-again
+          - name: K8GUARD_ACTION_DURATION_VIOLATION_EXPIRES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-violation-expires
+          - name: K8GUARD_ACTION_HIPCHAT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-action-secrets
+                key: hipchat-token
+          - name: K8GUARD_ACTION_HIPCHAT_ROOM_ID
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-room-id
+          - name: K8GUARD_ACTION_HIPCHAT_BASE_URL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-base-url
+          - name: K8GUARD_ACTION_HIPCHAT_TAG_NAMESPACE_OWNER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-tag-namespace-owner
+          - name: K8GUARD_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-log-level
+
+          - name: K8GUARD_CACHE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cache-type
+          - name: K8GUARD_MESSAGE_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-message-broker
+          - name: K8GUARD_RMQ_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-rmq-broker
+          - name: K8GUARD_RMQ_ACTION_TOPIC
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-rmq-action-topic
+
+          - name: K8GUARD_CASSANDRA_CREATE_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cassandra-create-keyspace
+          - name: K8GUARD_CASSANDRA_CREATE_TABLES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cassandra-create-tables
+          - name: K8GUARD_ACTION_VIOLATION_EMAIL_FOOTER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-action-violation-email-footer

--- a/minikube/action-lightweight/k8guard-action-secrets.yaml
+++ b/minikube/action-lightweight/k8guard-action-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-action-secrets
+data:
+  # passwords need to be base64, echo -n "REPLACE_ME" | base64
+  hipchat-token: "UkVQTEFDRV9NRQ=="
+  cassandra-password: "Y2Fzc2FuZHJh"

--- a/minikube/action-lightweight/k8guard-action-secrets.yaml.EXAMPLE
+++ b/minikube/action-lightweight/k8guard-action-secrets.yaml.EXAMPLE
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-action-secrets
+data:
+  # passwords need to be base64, echo -n "REPLACE_ME" | base64
+  hipchat-token: "UkVQTEFDRV9NRQ=="
+  cassandra-password: "Y2Fzc2FuZHJh"

--- a/minikube/core-lightweight/cassandra-deployment.yaml
+++ b/minikube/core-lightweight/cassandra-deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-cassandra
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8guard-cassandra
+    spec:
+      containers:
+      - name: k8guard-cassandra
+        image: bitnami/cassandra

--- a/minikube/core-lightweight/cassandra-svc.yaml
+++ b/minikube/core-lightweight/cassandra-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-cassandra-label
+  name: k8guard-cassandra-service
+spec:
+  ports:
+    # The port that this service should serve on.
+    - port: 9042
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-cassandra

--- a/minikube/core-lightweight/redis-deployment.yaml
+++ b/minikube/core-lightweight/redis-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-redis
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8guard-redis
+    spec:
+      containers:
+      - name: k8guard-redis
+        image: redis:alpine
+        ports:
+        - containerPort: 6379

--- a/minikube/core-lightweight/redis-svc.yaml
+++ b/minikube/core-lightweight/redis-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-redis-label
+  name: k8guard-redis-service
+spec:
+  ports:
+    # The port that this service should serve on.
+    - port: 6379
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-redis

--- a/minikube/discover-api-lightweight/k8guard-discover-configmap.yaml
+++ b/minikube/discover-api-lightweight/k8guard-discover-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-discover-configmap
+data:
+  k8guard-namespace: ""
+  k8guard-cluster: "tte-test"
+  k8guard-include-alpha: "FALSE"
+  k8guard-approved-image-repos: "REPLACE_ME"
+  k8guard-approved-image-size: "800"
+  k8guard-ingress-must-contain: ""
+  k8guard-ingress-must-not-contain: ""
+  k8guard-approved-ingress-suffixes: ""
+  k8guard-ignore-namespaces: ""
+  k8guard-ignore-pods-prefix: ""
+  k8guard-ignore-deployments: ""
+  k8guard-ignore-violations: ""
+  k8guard-required-annotations: ""
+  k8guard-required-labels: ""
+  k8guard-required-entities: ""
+  k8guard-output-pods-to-file: "FALSE"
+  k8guard-cache-expiration-seconds: "300"
+  k8guard-http-cache-expire: "TRUE"
+  k8guard-memcahced-hostname: "k8guard-memcached-service.default.svc.cluster.local"
+  k8guard-log-level: "debug"
+  k8guard-cache-type: "REDIS"
+  k8guard-message-broker: "RMQ"
+  k8guard-redis-broker: "redis:6379"
+  k8guard-redis-action-topic: "k8guard-to-action"

--- a/minikube/discover-api-lightweight/k8guard-discover-deployment.yaml
+++ b/minikube/discover-api-lightweight/k8guard-discover-deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-discover-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: k8guard-discover-api
+    spec:
+      containers:
+      - name: k8guard-discover
+        image: local/k8guard-discover
+        imagePullPolicy: Never
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-namespace
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cluster
+          - name: K8GUARD_INCLUDE_ALPHA
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-include-alpha
+          - name: K8GUARD_APPROVED_IMAGE_REPOS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-image-repos
+          - name: K8GUARD_APPROVED_IMAGE_SIZE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-image-size
+          - name: K8GUARD_INGRESS_MUST_CONTAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ingress-must-contain
+          - name: K8GUARD_INGRESS_MUST_NOT_CONTAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ingress-must-not-contain
+          - name: K8GUARD_APPROVED_INGRESS_SUFFIXES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-ingress-suffixes
+
+          - name: K8GUARD_IGNORE_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-namespaces
+          - name: K8GUARD_IGNORE_PODS_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-pods-prefix
+          - name: K8GUARD_REQUIRED_ANNOTATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-annotations
+          - name: K8GUARD_REQUIRED_LABELS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-labels
+          - name: K8GUARD_REQUIRED_ENTITIES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-entities
+          - name: K8GUARD_OUTPUT_PODS_TO_FILE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-output-pods-to-file
+          - name: K8GUARD_CACHE_EXPIRATION_SECONDS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cache-expiration-seconds
+          - name: K8GUARD_MEMCACHED_HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-memcahced-hostname
+          - name: K8GUARD_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-log-level
+          - name: K8GUARD_CACHE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cache-type
+          - name: K8GUARD_MESSAGE_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-message-broker
+          - name: K8GUARD_REDIS_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-redis-broker
+          - name: K8GUARD_REDIS_ACTION_TOPIC
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-redis-action-topic
+          - name: K8GUARD_IGNORED_VIOLATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-violations
+
+        ports:
+        - containerPort: 3000

--- a/minikube/discover-api-lightweight/k8guard-discover-svc.yaml
+++ b/minikube/discover-api-lightweight/k8guard-discover-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-label
+  name: k8guard-discover-service
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+spec:
+  type: NodePort
+  ports:
+    # The port that this service should serve on.
+    - port: 3000
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-discover-api

--- a/minikube/discover-cronjob-lightweight/k8guard-discover-cronjob.yaml
+++ b/minikube/discover-cronjob-lightweight/k8guard-discover-cronjob.yaml
@@ -1,0 +1,137 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: k8guard-discover-cronjob
+spec:
+  # At every 3rd minute. for local testing
+  schedule: "*/3 * * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: k8guard-discover-cronjob
+              image: local/k8guard-discover
+              imagePullPolicy: Never
+              args:
+                - -kmode
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 700Mi
+                requests:
+                  cpu: 300m
+                  memory: 350Mi
+              env:
+                - name: K8GUARD_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-namespace
+                - name: K8GUARD_CLUSTER_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cluster
+                - name: K8GUARD_INCLUDE_ALPHA
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-include-alpha
+                - name: K8GUARD_APPROVED_IMAGE_REPOS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-image-repos
+                - name: K8GUARD_APPROVED_IMAGE_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-image-size
+                - name: K8GUARD_APPROVED_INGRESS_SUFFIXES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-ingress-suffixes
+                - name: K8GUARD_INGRESS_MUST_NOT_CONTAIN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ingress-must-not-contain
+                - name: K8GUARD_IGNORE_NAMESPACES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-namespaces
+                - name: K8GUARD_IGNORE_PODS_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-pods-prefix
+                - name: K8GUARD_IGNORE_DEPLOYMENTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-deployments
+                - name: K8GUARD_REQUIRED_ANNOTATIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-annotations
+                - name: K8GUARD_REQUIRED_LABELS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-labels
+                - name: K8GUARD_REQUIRED_ENTITIES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-entities
+                - name: K8GUARD_OUTPUT_PODS_TO_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-output-pods-to-file
+                - name: K8GUARD_CACHE_EXPIRATION_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cache-expiration-seconds
+                - name: K8GUARD_MEMCACHED_HOSTNAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-memcahced-hostname
+                - name: K8GUARD_LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-log-level
+                - name: K8GUARD_CACHE_TYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cache-type
+                - name: K8GUARD_MESSAGE_BROKER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-message-broker
+                - name: K8GUARD_REDIS_BROKER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-redis-broker
+                - name: K8GUARD_REDIS_ACTION_TOPIC
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-redis-action-topic
+                - name: K8GUARD_IGNORED_VIOLATIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-violations

--- a/minikube/report-lightweight/k8guard-report-configmap.yaml
+++ b/minikube/report-lightweight/k8guard-report-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-report-configmap
+data:
+  k8guard-namespace: ""
+  k8guard-cluster: "minikube"
+  cassandra-username: "cassandra"
+  cassandra-ca-path: ""
+  cassandra-ssl-validation: "false"
+  cassandra-hosts: "k8guard-cassandra-service.default.svc.cluster.local:9042"
+  cassandra-keyspace: "k8guardkeyspace"

--- a/minikube/report-lightweight/k8guard-report-deployment.yaml
+++ b/minikube/report-lightweight/k8guard-report-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-report-deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: k8guard-report
+    spec:
+      containers:
+      - name: k8guard-report
+        image: local/k8guard-report
+        imagePullPolicy: Never
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: k8guard-namespace
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: k8guard-cluster
+          - name: K8GUARD_ACTION_CASSANDRA_HOSTS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-hosts
+          - name: K8GUARD_ACTION_CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-keyspace
+          - name: K8GUARD_ACTION_CASSANDRA_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-username
+          - name: K8GUARD_ACTION_CASSANDRA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-report-secrets
+                key: cassandra-password
+          - name: K8GUARD_ACTION_CASSANDRA_CAPATH
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-ca-path
+          - name: K8GUARD_ACTION_CASSANDRA_SSL_HOST_VALIDATION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-ssl-validation
+        ports:
+        - containerPort: 3001

--- a/minikube/report-lightweight/k8guard-report-secrets.yaml
+++ b/minikube/report-lightweight/k8guard-report-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-report-secrets
+data:
+  # passwords need to be base64, echo -n "cassandra" | base6
+  cassandra-password: "Y2Fzc2FuZHJh"

--- a/minikube/report-lightweight/k8guard-report-secrets.yaml.EXAMPLE
+++ b/minikube/report-lightweight/k8guard-report-secrets.yaml.EXAMPLE
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-report-secrets
+data:
+  # passwords need to be base64, echo -n "cassandra" | base6
+  cassandra-password: "Y2Fzc2FuZHJh"

--- a/minikube/report-lightweight/k8guard-report-svc.yaml
+++ b/minikube/report-lightweight/k8guard-report-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-label
+  name: k8guard-report-service
+spec:
+  type: NodePort
+  ports:
+    # The port that this service should serve on.
+    - port: 3001
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-report


### PR DESCRIPTION
Added support for an alternate lighter weight deployment of just Redis and Cassandra instead of Kafka, Zookeeper, Memcached and Cassandra.

Dependent upon PR https://github.com/k8guard/k8guard-start-from-here/pull/35.