### PR TITLE
allow namespacing helm deployment

### DIFF
--- a/helm/templates/cassandra-deployment.yaml
+++ b/helm/templates/cassandra-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: k8guard-cassandra
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
   template:

--- a/helm/templates/cassandra-svc.yaml
+++ b/helm/templates/cassandra-svc.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Values.namespace }}
   labels:
     name: k8guard-cassandra-label
   name: k8guard-cassandra-service

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
+  namespace {{ .Values.namespace }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/helm/templates/k8guard-action-configmap.yaml
+++ b/helm/templates/k8guard-action-configmap.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8guard-action-configmap
+  namespace: {{ .Values.namespace }}
 data:
 {{ toYaml .Values.action.configmap | indent 2 }}

--- a/helm/templates/k8guard-action-deployment.yaml
+++ b/helm/templates/k8guard-action-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.namespace }}
   name: k8guard-action-deployment
 spec:
   replicas: {{ .Values.action.deployment.replicas }}

--- a/helm/templates/k8guard-action-secrets.yaml
+++ b/helm/templates/k8guard-action-secrets.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: k8guard-action-secrets
+  namespace: {{ .Values.namespace }}
 data:
 {{ toYaml .Values.action.secrets | indent 2 }}

--- a/helm/templates/k8guard-discover-configmap.yaml
+++ b/helm/templates/k8guard-discover-configmap.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8guard-discover-configmap
+  namespace: {{ .Values.namespace }}
 data:
 {{ toYaml .Values.discover.configmap | indent 2 }}

--- a/helm/templates/k8guard-discover-cronjob.yaml
+++ b/helm/templates/k8guard-discover-cronjob.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
   name: k8guard-discover-cronjob
+  namespace: {{ .Values.namespace }}
 spec:
   schedule: "{{ .Values.discover.cronjob.schedule }}"
   concurrencyPolicy: Replace

--- a/helm/templates/k8guard-discover-deployment.yaml
+++ b/helm/templates/k8guard-discover-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: k8guard-discover-deployment
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.discover.deployment.replicas }}
   template:

--- a/helm/templates/k8guard-discover-svc.yaml
+++ b/helm/templates/k8guard-discover-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     name: k8guard-label
   name: k8guard-discover-service
+  namespace: {{ .Values.namespace }}
   annotations:
 {{ toYaml .Values.discover.service.annotations | indent 4 }}
 spec:

--- a/helm/templates/k8guard-report-configmap.yaml
+++ b/helm/templates/k8guard-report-configmap.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8guard-report-configmap
+  namespace: {{ .Values.namespace }}
 data:
 {{ toYaml .Values.report.configmap | indent 2 }}

--- a/helm/templates/k8guard-report-deployment.yaml
+++ b/helm/templates/k8guard-report-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: k8guard-report-deployment
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.report.deployment.replicas }}
   template:

--- a/helm/templates/k8guard-report-secrets.yaml
+++ b/helm/templates/k8guard-report-secrets.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ .Values.namespace }}
   name: k8guard-report-secrets
 data:
 {{ toYaml .Values.report.secrets | indent 2 }}

--- a/helm/templates/k8guard-report-svc.yaml
+++ b/helm/templates/k8guard-report-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     name: k8guard-label
   name: k8guard-report-service
+  namespace: {{ .Values.namespace }}
 spec:
   type: NodePort
   ports:

--- a/helm/templates/kafka-deployment.yaml
+++ b/helm/templates/kafka-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: k8guard-kafka
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
   template:

--- a/helm/templates/kafka-svc.yaml
+++ b/helm/templates/kafka-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     name: k8guard-kafka-label
   name: k8guard-kafka-service
+  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - port: 2181

--- a/helm/templates/memcached-deployment.yaml
+++ b/helm/templates/memcached-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: k8guard-memcached
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
   template:

--- a/helm/templates/memcached-svc.yaml
+++ b/helm/templates/memcached-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     name: k8guard-memcached-label
   name: k8guard-memcached-service
+  namespace: {{ .Values.namespace }}
 spec:
   ports:
     # The port that this service should serve on.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,3 +1,5 @@
+# All resources are installed into this namespace
+namespace: ""
 action:
   configmap:
     cluster-name: "minikube"


### PR DESCRIPTION
This way the k8guard resources can be installed within a variable namespace, if desired.