### PR TITLE
allow specifying resource limits in helm chart

### DIFF
--- a/helm/templates/cassandra-deployment.yaml
+++ b/helm/templates/cassandra-deployment.yaml
@@ -13,3 +13,7 @@ spec:
       containers:
       - name: k8guard-cassandra
         image: bitnami/cassandra
+{{ if .Values.cassandra.resources }}
+        resources:
+{{- end }}
+{{ toYaml .Values.cassandra.resources | indent 10 }}

--- a/helm/templates/kafka-deployment.yaml
+++ b/helm/templates/kafka-deployment.yaml
@@ -16,6 +16,10 @@ spec:
         # image: satlank/microzookeeper:3.4.9-1
         ports:
         - containerPort: 2181
+{{ if .Values.zookeeper.resources }}
+        resources:
+{{- end }}
+{{ toYaml .Values.zookeeper.resources | indent 10}}
       - name: kafka
         image: wurstmeister/kafka:0.10.2.1
         env:
@@ -29,3 +33,7 @@ spec:
             value: "k8guard-to-action-k8s-lab:1:1"
         ports:
         - containerPort: 9092
+{{ if .Values.kafka.resources }}
+        resources:
+{{- end }}
+{{ toYaml .Values.kafka.resources | indent 10 }}

--- a/helm/templates/memcached-deployment.yaml
+++ b/helm/templates/memcached-deployment.yaml
@@ -13,3 +13,7 @@ spec:
       containers:
       - name: k8guard-memcached
         image: memcached:alpine
+{{ if .Values.memcached.resources }}
+        resources:
+{{- end }}
+{{ toYaml .Values.memcached.resources | indent 10 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -97,3 +97,41 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
+
+# Optionally limit the resources used by the core services
+#cassandra:
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"
+#
+#memcached:
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"
+#
+#kafka:
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"
+#
+#zookeeper:
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"
+#


### PR DESCRIPTION
This allows defining the zookeeper, cassandra, kafka, and memcached resource limits.