### PR TITLE
Add lightweight helm chart

### DIFF
--- a/helm-lightweight/.helmignore
+++ b/helm-lightweight/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-lightweight/Chart.yaml
+++ b/helm-lightweight/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: The lightweight k8guard helm chart.
+name: helm-lightweight
+version: 0.1.0

--- a/helm-lightweight/templates/NOTES.txt
+++ b/helm-lightweight/templates/NOTES.txt
@@ -1,0 +1,8 @@
+
+{{- if .Values.ingress.hostname }}
+You can use the below URL to access the k8guard report and discover UIs:
+  http://{{- .Values.ingress.hostname }}/report
+  http://{{- .Values.ingress.hostname }}/discover
+{{- else }}
+Consider using an ingress to expose your report and discover services.
+{{- end }}

--- a/helm-lightweight/templates/_helpers.tpl
+++ b/helm-lightweight/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-lightweight/templates/cassandra-deployment.yaml
+++ b/helm-lightweight/templates/cassandra-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-cassandra
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8guard-cassandra
+{{ if .Values.cassandra.labels  }}
+{{ toYaml .Values.cassandra.labels | indent 8 }}
+{{ end }}
+    spec:
+      containers:
+      - name: k8guard-cassandra
+        image: bitnami/cassandra
+{{ if .Values.cassandra.resources }}
+        resources:
+{{- end }}
+{{ toYaml .Values.cassandra.resources | indent 10 }}

--- a/helm-lightweight/templates/cassandra-svc.yaml
+++ b/helm-lightweight/templates/cassandra-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-cassandra-label
+  name: k8guard-cassandra-service
+spec:
+  ports:
+    # The port that this service should serve on.
+    - port: 9042
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-cassandra

--- a/helm-lightweight/templates/ingress.yaml
+++ b/helm-lightweight/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace {{ .Values.namespace }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/helm-lightweight/templates/k8guard-action-configmap.yaml
+++ b/helm-lightweight/templates/k8guard-action-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-action-configmap
+  namespace: {{ .Values.namespace }}
+data:
+{{ toYaml .Values.action.configmap | indent 2 }}

--- a/helm-lightweight/templates/k8guard-action-deployment.yaml
+++ b/helm-lightweight/templates/k8guard-action-deployment.yaml
@@ -1,0 +1,179 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-action-deployment
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.action.deployment.replicas }}
+  template:
+    metadata:
+      labels:
+        app: k8guard-action
+{{ if .Values.action.deployment.labels }}
+{{- toYaml .Values.action.deployment.labels | indent 8 }}
+{{ end }}
+    spec:
+      containers:
+      - name: k8guard-action
+        image: {{ .Values.action.deployment.image }}
+        imagePullPolicy: {{ .Values.action.deployment.imagePullPolicy }}
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cluster-name
+          - name: K8GUARD_ACTION_CASSANDRA_HOSTS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-hosts
+          - name: K8GUARD_ACTION_CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-keyspace
+          - name: K8GUARD_ACTION_CASSANDRA_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-username
+          - name: K8GUARD_ACTION_CASSANDRA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-action-secrets
+                key: cassandra-password
+          - name: K8GUARD_ACTION_CASSANDRA_CAPATH
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-ca-path
+          - name: K8GUARD_ACTION_CASSANDRA_SSL_HOST_VALIDATION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: cassandra-ssl-validation
+          - name: K8GUARD_ACTION_SMTP_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-server
+          - name: K8GUARD_ACTION_SMTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-port
+          - name: K8GUARD_ACTION_SMTP_SEND_FROM
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-send-from
+          - name: K8GUARD_ACTION_SMTP_FALLBACK_SEND_TO
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-fallback-send-to
+          - name: K8GUARD_ACTION_SMTP_SEND_TO_NAMESAPCE_OWNER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: smtp-send-to-namespace-owner
+          - name: K8GUARD_ACTION_SAFE_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-safe-mode
+          - name: K8GUARD_ACTION_DRY_RUN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-dry-run
+          - name: K8GUARD_ACTION_WARNING_COUNT_BEFORE_ACTION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-warning-count-before_action
+          - name: K8GUARD_ACTION_DURATION_BETWEEN_CHAT_NOTIFICATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-between-chat-notifications
+          - name: K8GUARD_ACTION_DURATION_BETWEEN_NOTIFYING_AGAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-between-notifying-again
+          - name: K8GUARD_ACTION_DURATION_VIOLATION_EXPIRES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: action-duration-violation-expires
+          - name: K8GUARD_ACTION_HIPCHAT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-action-secrets
+                key: hipchat-token
+          - name: K8GUARD_ACTION_HIPCHAT_ROOM_ID
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-room-id
+          - name: K8GUARD_ACTION_HIPCHAT_BASE_URL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-base-url
+          - name: K8GUARD_ACTION_HIPCHAT_TAG_NAMESPACE_OWNER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: hipchat-tag-namespace-owner
+          - name: K8GUARD_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-log-level
+
+          - name: K8GUARD_CACHE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cache-type
+          - name: K8GUARD_MESSAGE_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-message-broker
+          - name: K8GUARD_RMQ_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-rmq-broker
+          - name: K8GUARD_RMQ_ACTION_TOPIC
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-rmq-action-topic
+
+          - name: K8GUARD_CASSANDRA_CREATE_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cassandra-create-keyspace
+          - name: K8GUARD_CASSANDRA_CREATE_TABLES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-cassandra-create-tables
+          - name: K8GUARD_ACTION_VIOLATION_EMAIL_FOOTER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-action-configmap
+                key: k8guard-action-violation-email-footer

--- a/helm-lightweight/templates/k8guard-action-secrets.yaml
+++ b/helm-lightweight/templates/k8guard-action-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-action-secrets
+  namespace: {{ .Values.namespace }}
+data:
+{{ toYaml .Values.action.secrets | indent 2 }}

--- a/helm-lightweight/templates/k8guard-discover-configmap.yaml
+++ b/helm-lightweight/templates/k8guard-discover-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-discover-configmap
+  namespace: {{ .Values.namespace }}
+data:
+{{ toYaml .Values.discover.configmap | indent 2 }}

--- a/helm-lightweight/templates/k8guard-discover-cronjob.yaml
+++ b/helm-lightweight/templates/k8guard-discover-cronjob.yaml
@@ -1,0 +1,138 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: k8guard-discover-cronjob
+  namespace: {{ .Values.namespace }}
+spec:
+  # At every 3rd minute. for local testing
+  schedule: "{{ .Values.discover.cronjob.schedule }}"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: k8guard-discover-cronjob
+              image: {{ .Values.discover.cronjob.image }}
+              imagePullPolicy: {{ .Values.discover.cronjob.imagePullPolicy }}
+              args:
+                - -kmode
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 700Mi
+                requests:
+                  cpu: 300m
+                  memory: 350Mi
+              env:
+                - name: K8GUARD_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-namespace
+                - name: K8GUARD_CLUSTER_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cluster
+                - name: K8GUARD_INCLUDE_ALPHA
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-include-alpha
+                - name: K8GUARD_APPROVED_IMAGE_REPOS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-image-repos
+                - name: K8GUARD_APPROVED_IMAGE_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-image-size
+                - name: K8GUARD_APPROVED_INGRESS_SUFFIXES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-approved-ingress-suffixes
+                - name: K8GUARD_INGRESS_MUST_NOT_CONTAIN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ingress-must-not-contain
+                - name: K8GUARD_IGNORE_NAMESPACES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-namespaces
+                - name: K8GUARD_IGNORE_PODS_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-pods-prefix
+                - name: K8GUARD_IGNORE_DEPLOYMENTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-deployments
+                - name: K8GUARD_REQUIRED_ANNOTATIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-annotations
+                - name: K8GUARD_REQUIRED_LABELS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-labels
+                - name: K8GUARD_REQUIRED_ENTITIES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-required-entities
+                - name: K8GUARD_OUTPUT_PODS_TO_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-output-pods-to-file
+                - name: K8GUARD_CACHE_EXPIRATION_SECONDS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cache-expiration-seconds
+                - name: K8GUARD_MEMCACHED_HOSTNAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-memcahced-hostname
+                - name: K8GUARD_LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-log-level
+                - name: K8GUARD_CACHE_TYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-cache-type
+                - name: K8GUARD_MESSAGE_BROKER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-message-broker
+                - name: K8GUARD_REDIS_BROKER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-redis-broker
+                - name: K8GUARD_REDIS_ACTION_TOPIC
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-redis-action-topic
+                - name: K8GUARD_IGNORED_VIOLATIONS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: k8guard-discover-configmap
+                      key: k8guard-ignore-violations

--- a/helm-lightweight/templates/k8guard-discover-deployment.yaml
+++ b/helm-lightweight/templates/k8guard-discover-deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-discover-deployment
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.discover.deployment.replicas }}
+  template:
+    metadata:
+      labels:
+        app: k8guard-discover-api
+{{ if .Values.discover.deployment.labels }}
+{{- toYaml .Values.discover.deployment.labels | indent 8 }}
+{{ end }}
+    spec:
+      containers:
+      - name: k8guard-discover
+        image: {{ .Values.discover.deployment.image }}
+        imagePullPolicy: {{ .Values.discover.deployment.imagePullPolicy }}
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-namespace
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cluster
+          - name: K8GUARD_INCLUDE_ALPHA
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-include-alpha
+          - name: K8GUARD_APPROVED_IMAGE_REPOS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-image-repos
+          - name: K8GUARD_APPROVED_IMAGE_SIZE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-image-size
+          - name: K8GUARD_INGRESS_MUST_CONTAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ingress-must-contain
+          - name: K8GUARD_INGRESS_MUST_NOT_CONTAIN
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ingress-must-not-contain
+          - name: K8GUARD_APPROVED_INGRESS_SUFFIXES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-approved-ingress-suffixes
+
+          - name: K8GUARD_IGNORE_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-namespaces
+          - name: K8GUARD_IGNORE_PODS_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-pods-prefix
+          - name: K8GUARD_REQUIRED_ANNOTATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-annotations
+          - name: K8GUARD_REQUIRED_LABELS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-labels
+          - name: K8GUARD_REQUIRED_ENTITIES
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-required-entities
+          - name: K8GUARD_OUTPUT_PODS_TO_FILE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-output-pods-to-file
+          - name: K8GUARD_CACHE_EXPIRATION_SECONDS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cache-expiration-seconds
+          - name: K8GUARD_MEMCACHED_HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-memcahced-hostname
+          - name: K8GUARD_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-log-level
+          - name: K8GUARD_CACHE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-cache-type
+          - name: K8GUARD_MESSAGE_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-message-broker
+          - name: K8GUARD_REDIS_BROKER
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-redis-broker
+          - name: K8GUARD_REDIS_ACTION_TOPIC
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-redis-action-topic
+          - name: K8GUARD_IGNORED_VIOLATIONS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-discover-configmap
+                key: k8guard-ignore-violations
+
+        ports:
+        - containerPort: 3000

--- a/helm-lightweight/templates/k8guard-discover-svc.yaml
+++ b/helm-lightweight/templates/k8guard-discover-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-label
+  name: k8guard-discover-service
+  namespace: {{ .Values.namespace }}
+  annotations:
+{{ toYaml .Values.discover.service.annotations | indent 4 }}
+spec:
+  type: NodePort
+  ports:
+    # The port that this service should serve on.
+    - port: {{ .Values.discover.service.port }}
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-discover-api

--- a/helm-lightweight/templates/k8guard-report-configmap.yaml
+++ b/helm-lightweight/templates/k8guard-report-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8guard-report-configmap
+  namespace: {{ .Values.namespace }}
+data:
+{{ toYaml .Values.report.configmap | indent 2 }}

--- a/helm-lightweight/templates/k8guard-report-deployment.yaml
+++ b/helm-lightweight/templates/k8guard-report-deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-report-deployment
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.report.deployment.replicas }}
+  template:
+    metadata:
+      labels:
+        app: k8guard-report
+{{ if .Values.report.deployment.labels }}
+{{- toYaml .Values.report.deployment.labels | indent 8 }}
+{{ end }}
+    spec:
+      containers:
+      - name: k8guard-report
+        image: {{ .Values.report.deployment.image }}
+        imagePullPolicy: {{ .Values.report.deployment.imagePullPolicy }}
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 10Mi
+        env:
+          - name: K8GUARD_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: k8guard-namespace
+          - name: K8GUARD_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: k8guard-cluster
+          - name: K8GUARD_ACTION_CASSANDRA_HOSTS
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-hosts
+          - name: K8GUARD_ACTION_CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-keyspace
+          - name: K8GUARD_ACTION_CASSANDRA_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-username
+          - name: K8GUARD_ACTION_CASSANDRA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: k8guard-report-secrets
+                key: cassandra-password
+          - name: K8GUARD_ACTION_CASSANDRA_CAPATH
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-ca-path
+          - name: K8GUARD_ACTION_CASSANDRA_SSL_HOST_VALIDATION
+            valueFrom:
+              configMapKeyRef:
+                name: k8guard-report-configmap
+                key: cassandra-ssl-validation
+        ports:
+        - containerPort: {{ .Values.report.deployment.containerPort }}
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: {{ .Values.report.deployment.containerPort }}
+          initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: {{ .Values.report.deployment.containerPort }}
+          initialDelaySeconds: 10
+          timeoutSeconds: 3

--- a/helm-lightweight/templates/k8guard-report-secrets.yaml
+++ b/helm-lightweight/templates/k8guard-report-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8guard-report-secrets
+  namespace: {{ .Values.namespace }}
+data:
+{{ toYaml .Values.report.secrets | indent 2 }}

--- a/helm-lightweight/templates/k8guard-report-svc.yaml
+++ b/helm-lightweight/templates/k8guard-report-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-label
+  name: k8guard-report-service
+  namespace: {{ .Values.namespace }}
+spec:
+  type: NodePort
+  ports:
+    # The port that this service should serve on.
+    - port: {{ .Values.report.service.port }}
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-report

--- a/helm-lightweight/templates/redis-deployment.yaml
+++ b/helm-lightweight/templates/redis-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8guard-redis
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8guard-redis
+{{ if .Values.redis.labels }}
+{{- toYaml .Values.redis.labels | indent 8 }}
+{{ end }}
+    spec:
+      containers:
+      - name: k8guard-redis
+        image: redis:alpine
+        ports:
+        - containerPort: 6379
+{{ if .Values.redis.resources }}
+        resources:
+{{ toYaml .Values.redis.resources | indent 10 }}
+{{- end }}

--- a/helm-lightweight/templates/redis-svc.yaml
+++ b/helm-lightweight/templates/redis-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: k8guard-redis-label
+  name: k8guard-redis-service
+spec:
+  ports:
+    # The port that this service should serve on.
+    - port: 6379
+
+  # Label keys and values that must match in order to receive traffic for this service.
+  selector:
+     app: k8guard-redis

--- a/helm-lightweight/values.yaml
+++ b/helm-lightweight/values.yaml
@@ -1,0 +1,130 @@
+# All resources are installed into this namespace
+namespace: ""
+action:
+  configmap:
+    cluster-name: "minikube"
+    hipchat-room-id: ""
+    hipchat-base-url: ""
+    hipchat-tag-namespace-owner: "true"
+    k8guard-log-level: "debug"
+    k8guard-cache-type: "REDIS"
+    k8guard-message-broker: "RMQ"
+    k8guard-rmq-broker: "redis:6379"
+    k8guard-rmq-action-topic: "k8guard-to-action"
+    cassandra-hosts: "k8guard-cassandra-service.default.svc.cluster.local:9042"
+    cassandra-keyspace: "k8guardkeyspace"
+    cassandra-username: "cassandra"
+    cassandra-ca-path: ""
+    cassandra-ssl-validation: "false"
+    k8guard-cassandra-create-keyspace: "true"
+    k8guard-cassandra-create-tables: "true"
+    smtp-server: ""
+    smtp-port: "25"
+    smtp-send-from: "DO_NOT_REPLY@REPLACE_WITH_DOMAIN.COM"
+    smtp-fallback-send-to: "REPLACE@REPLACE_WITH_DOMAIN.COM"
+    smtp-send-to-namespace-owner: "true"
+    action-safe-mode: "true"
+    action-dry-run: "false"
+    action-duration-between-chat-notifications: "30s"
+    action-warning-count-before_action: "4"
+    action-duration-between-notifying-again: "24h"
+    action-duration-violation-expires: "120h"
+    k8guard-action-violation-email-footer: ""
+  deployment:
+    replicas: 1
+    image: local/k8guard-discover
+    imagePullPolicy: IfNotPresent
+discover:
+  configmap:
+    k8guard-namespace: ""
+    k8guard-cluster: "tte-test"
+    k8guard-include-alpha: "FALSE"
+    k8guard-approved-image-repos: "REPLACE_ME"
+    k8guard-approved-image-size: "800"
+    k8guard-ingress-must-contain: ""
+    k8guard-ingress-must-not-contain: ""
+    k8guard-approved-ingress-suffixes: ""
+    k8guard-ignore-namespaces: ""
+    k8guard-ignore-pods-prefix: ""
+    k8guard-ignore-deployments: ""
+    k8guard-ignore-violations: ""
+    k8guard-required-annotations: ""
+    k8guard-required-labels: ""
+    k8guard-required-entities: ""
+    k8guard-output-pods-to-file: "FALSE"
+    k8guard-cache-expiration-seconds: "300"
+    k8guard-http-cache-expire: "TRUE"
+    k8guard-memcahced-hostname: "k8guard-memcached-service.default.svc.cluster.local"
+    k8guard-log-level: "debug"
+    k8guard-cache-type: "REDIS"
+    k8guard-message-broker: "RMQ"
+    k8guard-redis-broker: "redis:6379"
+    k8guard-redis-action-topic: "k8guard-to-action"
+  cronjob:
+    image: local/k8guard-discover
+    imagePullPolicy: IfNotPresent
+    schedule: "*/3 * * * *"
+  deployment:
+    replicas: 2
+    image: local/k8guard-action
+    imagePullPolicy: IfNotPresent
+  service:
+    port: 3000
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: '/metrics'
+report:
+  configmap:
+    k8guard-namespace: ""
+    k8guard-cluster: "minikube"
+    cassandra-username: "cassandra"
+    cassandra-ca-path: ""
+    cassandra-ssl-validation: "false"
+    cassandra-hosts: "k8guard-cassandra-service.default.svc.cluster.local:9042"
+    cassandra-keyspace: "k8guardkeyspace"
+  deployment:
+    replicas: 2
+    image: local/k8guard-report
+    imagePullPolicy: IfNotPresent
+    containerPort: 3001
+  secrets:
+    # passwords need to be base64, echo -n "cassandra" | base6
+    cassandra-password: "Y2Fzc2FuZHJh"
+  service:
+    port: 3001
+
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  host: k8guard.domain.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+
+cassandra:
+  labels: {}
+# Optionally limit the resources used by the core services
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"
+#
+redis:
+  labels: {}
+# Optionally limit the resources used by the core services
+#  resources:
+#    requests:
+#      memory: "64Mi"
+#      cpu: "250m"
+#    limits:
+#      memory: "128Mi"
+#      cpu: "500m"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: The k8guard helm chart.
 name: helm
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
This might be better if it was part of the existing helm chart, so that there is only one. Then we can have a variable in the values.yaml `use_lightweight` or something, that uses this version if supplied. Or, maybe two charts is fine.